### PR TITLE
Fix output type for textstat_simil call

### DIFF
--- a/R/LexisNexisTools.R
+++ b/R/LexisNexisTools.R
@@ -934,12 +934,12 @@ lnt_similarity <- function(texts,
   duplicates.df <- lapply(dates.d, function(x) {
     if (sum(x == na.omit(dates)) > 1) {
       text_dfm_day <- quanteda::dfm_subset(text_dfm, subset = (dates == x))
-      sim <- quanteda::textstat_simil(
+      sim <- stats::as.dist(quanteda::textstat_simil(
         text_dfm_day,
         selection = NULL,
         method = "cosine",
         margin = "documents"
-      )
+      ))
       . <- t(combn(as.numeric(quanteda::docnames(text_dfm_day)), 2))
       colnames(.) <- c("ID_original", "ID_duplicate")
       duplicates.df <- data.frame(


### PR DESCRIPTION
Ensures that the output of textstat_simil() is the same for **quanteda** 1.4.3 and 1.5. In v1.5, we have changed the output format for `textstat_simil()` and `textstat_dist()` objects to a sparse, symmetric matrix object. Coercing this output using `as.dist()` ensures that that format is identical to pre-1.4 versions.

We are about to refresh CRAN so 1.5 will break **LexisNexisTools** unless this change is made.