### PR TITLE
use expect_equivalent() instead of expect_equal()

### DIFF
--- a/tests/testthat/test-lnt_convert.R
+++ b/tests/testthat/test-lnt_convert.R
@@ -99,7 +99,7 @@ test_that("Convert LNToutput to corpustools", {
 # }, "../files/corpustools.RDS")
 
 test_that("Convert LNToutput to tidytext", {
-  expect_equal({
+  expect_equivalent({
     lnt_convert(x = readRDS("../files/LNToutput.RDS"),
                            to = "tidytext", what = "Articles")
   }, readRDS("../files/tidytext.RDS"))


### PR DESCRIPTION
Please consider this minor fix to the tests, using expect_equivalent() instead of expect_equal() will consider equivalent a data frame and a tibble with same data. 

This was discovered when testing against dplyr 1.0.0 which is about to get released: 

```
[master] 128.3 MiB ❯ revdepcheck::revdep_details(, "LexisNexisTools")
══ Reverse dependency check ═══════════════════════════ LexisNexisTools 0.3.0 ══

Status: BROKEN

── Newly failing

✖ checking tests ...

── Before ──────────────────────────────────────────────────────────────────────
0 errors ✔ | 0 warnings ✔ | 0 notes ✔

── After ───────────────────────────────────────────────────────────────────────
❯ checking tests ...
  See below...

── Test failures ───────────────────────────────────────────────── testthat ────

> library("testthat")
> library("LexisNexisTools")
LexisNexisTools Version 0.3.0
>
> test_check("LexisNexisTools")
── 1. Failure: Convert LNToutput to tidytext (@test-lnt_convert.R#102)  ────────
{
    ...
} not equal to readRDS("../files/tidytext.RDS").
Attributes: < Component "class": Lengths (3, 1) differ (string compare on first 1) >
Attributes: < Component "class": 1 string mismatch >
Attributes: < Component "row.names": Modes: numeric, character >
Attributes: < Component "row.names": target is numeric, current is character >

  |++++++++++++++++++++++++++++++++++++++++++++++++++| 100% elapsed=00s
══ testthat results  ═══════════════════════════════════════════════════════════
[ OK: 97 | SKIPPED: 2 | WARNINGS: 0 | FAILED: 1 ]
1. Failure: Convert LNToutput to tidytext (@test-lnt_convert.R#102)

Error: testthat unit tests failed
Execution halted

1 error ✖ | 0 warnings ✔ | 0 notes ✔
```